### PR TITLE
Android X Update

### DIFF
--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/CursorResultSubscriber.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/CursorResultSubscriber.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.list.FlowCursorIterator;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXModelQueriable.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXModelQueriable.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXModelQueriableImpl.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXModelQueriableImpl.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXQueriable.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXQueriable.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx.language;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXQueriableImpl.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXQueriableImpl.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx.language;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.BaseQueriable;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXSQLite.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/RXSQLite.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.sql.queriable.Queriable;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/TableChangeListenerEmitter.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/language/TableChangeListenerEmitter.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.runtime.OnTableChangedListener;

--- a/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/structure/BaseRXModel.java
+++ b/dbflow-rx/src/main/java/com/raizlabs/android/dbflow/rx/structure/BaseRXModel.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/CursorResultFlowable.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/CursorResultFlowable.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.list.FlowCursorIterator;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriable.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriable.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriable.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriable.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriableImpl.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriableImpl.java
@@ -1,7 +1,10 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
+import static io.reactivex.Single.fromCallable;
+
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.BaseQueriable;
@@ -14,8 +17,6 @@ import java.util.concurrent.Callable;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
-
-import static io.reactivex.Single.fromCallable;
 
 /**
  * Description: Represents {@link BaseQueriable} with RX constructs.

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXSQLite.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXSQLite.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/TableChangeOnSubscribe.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/TableChangeOnSubscribe.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.rx2.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.runtime.OnTableChangedListener;

--- a/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherDatabase.java
+++ b/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherDatabase.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sqlcipher;
 
 import android.content.ContentValues;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherOpenHelper.java
+++ b/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherOpenHelper.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sqlcipher;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseConfig;
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;

--- a/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherStatement.java
+++ b/dbflow-sqlcipher/src/main/java/com/raizlabs/android/dbflow/sqlcipher/SQLCipherStatement.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sqlcipher;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.database.BaseDatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;

--- a/dbflow/build.gradle
+++ b/dbflow/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     api project("${dbflow_project_prefix}dbflow-core")
-    api "com.android.support:support-annotations:26.0.1"
+    api "androidx.annotation:annotation:1.2.0"
 }
 
 apply from: '../android-artifacts.gradle'

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseConfig.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseConfig.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.config;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.StringUtils;
 import com.raizlabs.android.dbflow.runtime.BaseTransactionManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.config;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.annotation.QueryModel;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowConfig.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowConfig.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.config;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.config;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.converter.TypeConverter;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/TableConfig.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/TableConfig.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.config;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.queriable.ListModelLoader;
 import com.raizlabs.android.dbflow.sql.queriable.SingleModelLoader;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorIterator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorIterator.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.list;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ConcurrentModificationException;
 import java.util.ListIterator;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.list;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.widget.ListView;
 
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -7,8 +7,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.StringUtils;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/IFlowCursorIterator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/IFlowCursorIterator.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.list;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
@@ -3,7 +3,7 @@ package com.raizlabs.android.dbflow.runtime;
 import android.content.ContentProvider;
 import android.content.ContentValues;
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.DatabaseHolder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseTransactionManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseTransactionManager.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.runtime;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ContentResolverNotifier.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ContentResolverNotifier.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.runtime;
 
 import android.content.ContentResolver;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.SqlUtils;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/DBBatchSaveQueue.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/DBBatchSaveQueue.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.runtime;
 
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/DirectModelNotifier.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/DirectModelNotifier.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.runtime;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseConfig;
 import com.raizlabs.android.dbflow.structure.BaseModel;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
@@ -8,8 +8,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseConfig;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ModelNotifier.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ModelNotifier.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.runtime;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/NotifyDistributor.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/NotifyDistributor.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.runtime;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.structure.BaseModel;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/OnTableChangedListener.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/OnTableChangedListener.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.runtime;
 
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.BaseModel;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/StubContentProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/StubContentProvider.java
@@ -8,8 +8,8 @@ import android.content.ContentProvider;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Used as a stub, include this in order to work around Android O changes to {@link ContentProvider}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/TableNotifierRegister.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/TableNotifierRegister.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.runtime;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Defines how {@link ModelNotifier} registers listeners. Abstracts that away.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/BaseAsyncObject.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/BaseAsyncObject.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -3,8 +3,8 @@ package com.raizlabs.android.dbflow.sql;
 import android.content.ContentValues;
 import android.database.ContentObserver;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.StringUtils;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Actionable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Actionable.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.BaseModel.Action;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseOperator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseOperator.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.database.DatabaseUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.converter.TypeConverter;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
@@ -3,7 +3,7 @@ package com.raizlabs.android.dbflow.sql.language;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDoneException;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseTransformable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseTransformable.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Case.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Case.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CaseCondition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CaseCondition.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CompletedTrigger.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CompletedTrigger.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CursorResult.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/CursorResult.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.list.FlowCursorIterator;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Delete.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Delete.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ExistenceOperator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ExistenceOperator.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IConditional.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IConditional.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IOperator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IOperator.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Index.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Index.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IndexedBy.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/IndexedBy.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.content.ContentValues;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Join.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Join.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Method.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Method.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.SQLiteType;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/NameAlias.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/NameAlias.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.StringUtils;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Operator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Operator.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Collate;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OperatorGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OperatorGroup.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.Collate;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/SQLOperator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/SQLOperator.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/SQLite.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/SQLite.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 import com.raizlabs.android.dbflow.sql.language.property.Property;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.content.ContentValues;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Transformable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Transformable.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Trigger.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Trigger.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/TriggerMethod.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/TriggerMethod.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/UnSafeStringOperator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/UnSafeStringOperator.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.StringUtils;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Update.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Update.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.provider.ContentProvider;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/WhereBase.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/WhereBase.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IProperty.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.language.Join;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/Property.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/Property.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.BaseModelQueriable;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/PropertyFactory.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/PropertyFactory.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.NameAlias;
 import com.raizlabs.android.dbflow.sql.language.Operator;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/TypeConvertedProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/TypeConvertedProperty.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.converter.TypeConverter;
 import com.raizlabs.android.dbflow.sql.language.NameAlias;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/WrapperProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/WrapperProperty.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.NameAlias;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/AlterTableMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/AlterTableMigration.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
 import android.database.Cursor;
-import android.support.annotation.CallSuper;
-import android.support.annotation.NonNull;
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/BaseMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/BaseMigration.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -1,7 +1,8 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
-import android.support.annotation.CallSuper;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.Index;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.property.IndexProperty;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/Migration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/Migration.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/UpdateTableMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/UpdateTableMigration.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.migration;
 
-import android.support.annotation.CallSuper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.BaseQueriable;
 import com.raizlabs.android.dbflow.sql.language.OperatorGroup;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/AsyncQuery.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/AsyncQuery.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.BaseAsyncObject;
 import com.raizlabs.android.dbflow.structure.database.transaction.QueryTransaction;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableListModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.sql.queriable;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.language.Delete;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleKeyCacheableListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleKeyCacheableListModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleKeyCacheableModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleKeyCacheableModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.queriable;
 
 import android.database.sqlite.SQLiteDatabase;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/AutoIncrementModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/AutoIncrementModelSaver.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.saveable;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.runtime.NotifyDistributor;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/CacheableListModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/CacheableListModelSaver.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.saveable;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.sql.saveable;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.sql.saveable;
 
 import android.content.ContentValues;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.BaseAsyncObject;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseQueryModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseQueryModel.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.QueryModel;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
@@ -2,9 +2,10 @@ package com.raizlabs.android.dbflow.structure;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/Model.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/Model.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.transaction.DefaultTransactionQueue;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/NoModificationModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/NoModificationModel.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.QueryModel;
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ReadOnlyModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ReadOnlyModel.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.migration.Migration;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
@@ -1,8 +1,9 @@
 package com.raizlabs.android.dbflow.structure;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseConfig;
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/IMultiKeyCacheConverter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/IMultiKeyCacheConverter.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.Model;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: A generic cache for models that is implemented or can be implemented to your liking.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.Table;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/SimpleMapCache.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/SimpleMapCache.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.structure.Model;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.SparseArray;
 
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabase.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabase.java
@@ -3,8 +3,8 @@ package com.raizlabs.android.dbflow.structure.database;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Specifies the android default implementation of a database.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabaseStatement.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabaseStatement.java
@@ -5,8 +5,8 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description:

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database;
 
 import android.database.sqlite.SQLiteException;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseStatement.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseStatement.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Default implementation for some {@link DatabaseStatement} methods.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperDelegate.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperDelegate.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure.database;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperListener.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperListener.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Description: Provides callbacks for {@link OpenHelper} methods

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseStatement.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseStatement.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.structure.database;
 
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Abstracts out a {@link SQLiteStatement}.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseStatementWrapper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseStatementWrapper.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.runtime.NotifyDistributor;
 import com.raizlabs.android.dbflow.sql.language.BaseQueriable;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseWrapper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseWrapper.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.structure.database;
 
 import android.content.ContentValues;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Provides a base implementation that wraps a database, so other database engines potentially can

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowCursor.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowCursor.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure.database;
 
 import android.database.Cursor;
 import android.database.CursorWrapper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Common {@link Cursor} class that wraps cursors we use in this library with convenience loading methods.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowSQLiteOpenHelper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowSQLiteOpenHelper.java
@@ -3,8 +3,8 @@ package com.raizlabs.android.dbflow.structure.database;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/OpenHelper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/OpenHelper.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Description: Abstracts out the {@link DatabaseHelperDelegate} into the one used in this library.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/DefaultTransactionManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/DefaultTransactionManager.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.runtime.BaseTransactionManager;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/DefaultTransactionQueue.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/DefaultTransactionQueue.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
 import android.os.Looper;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/FastStoreModelTransaction.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/FastStoreModelTransaction.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/ITransactionQueue.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/ITransactionQueue.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Description: Interface for a queue that manages transactions.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/PriorityTransactionQueue.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/PriorityTransactionQueue.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
 import android.os.Looper;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/PriorityTransactionWrapper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/PriorityTransactionWrapper.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/ProcessModelTransaction.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/ProcessModelTransaction.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/QueryTransaction.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/QueryTransaction.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.database.transaction;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.CursorResult;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/Transaction.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/transaction/Transaction.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure.database.transaction;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.DatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/listener/LoadFromCursorListener.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/listener/LoadFromCursorListener.java
@@ -1,7 +1,7 @@
 package com.raizlabs.android.dbflow.structure.listener;
 
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.Model;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/listener/SQLiteStatementListener.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/listener/SQLiteStatementListener.java
@@ -1,6 +1,6 @@
 package com.raizlabs.android.dbflow.structure.listener;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseProviderModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseProviderModel.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure.provider;
 
 import android.content.ContentProvider;
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.OperatorGroup;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseSyncableProviderModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseSyncableProviderModel.java
@@ -1,8 +1,8 @@
 package com.raizlabs.android.dbflow.structure.provider;
 
 import android.content.ContentProvider;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.OperatorGroup;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ModelProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ModelProvider.java
@@ -2,8 +2,8 @@ package com.raizlabs.android.dbflow.structure.provider;
 
 import android.content.ContentResolver;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.Operator;
 import com.raizlabs.android.dbflow.sql.language.OperatorGroup;

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ dbflow_build_tools_version=26.0.2
 dbflow_min_sdk=4
 dbflow_min_sdk_rx=15
 dbflow_target_sdk=26
+
+android.useAndroidX=true


### PR DESCRIPTION
It would be great to have a release branch from the tag `4.2.4` that I could merge this into and then tag that branch with a `4.2.5` release. Right now I have to include `Jetifier=true` in the gradle.properties file because DBFlow is using the support annotations library. It would be nice not to need that to increase build performance. 